### PR TITLE
Implement IOPaint as touch-up backend

### DIFF
--- a/app.go
+++ b/app.go
@@ -59,17 +59,23 @@ type App struct {
 	// Launch arguments (set before startup)
 	launchFilePath string
 	launchMode     string // "corner", "disc", or "line"
+
+	// Touch-up backend settings
+	touchupBackend string // "patchmatch" or "iopaint"
+	iopaintURL     string
 }
 
 // NewApp creates a new App application struct.
 func NewApp() *App {
 	return &App{
-		undoLimit:     10,
-		featherSize:   15,
-		cropAmount:    3,
-		undoStack:     []*image.NRGBA{},
-		bgColor:       color.NRGBA{R: 255, G: 255, B: 255, A: 255},
-		postDiscWhite: 255,
+		undoLimit:      10,
+		featherSize:    15,
+		cropAmount:     3,
+		undoStack:      []*image.NRGBA{},
+		bgColor:        color.NRGBA{R: 255, G: 255, B: 255, A: 255},
+		postDiscWhite:  255,
+		touchupBackend: "patchmatch",
+		iopaintURL:     "http://127.0.0.1:8086/",
 	}
 }
 

--- a/app_iopaint.go
+++ b/app_iopaint.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// iopaintRequest mirrors the JSON body expected by the IOPaint /api/v1/inpaint endpoint.
+type iopaintRequest struct {
+	Image                       string      `json:"image"`
+	Mask                        string      `json:"mask"`
+	LDMSteps                    int         `json:"ldm_steps"`
+	LDMSampler                  string      `json:"ldm_sampler"`
+	ZITSWireframe               bool        `json:"zits_wireframe"`
+	CV2Flag                     string      `json:"cv2_flag"`
+	CV2Radius                   int         `json:"cv2_radius"`
+	HDStrategy                  string      `json:"hd_strategy"`
+	HDStrategyCropTriggerSize   int         `json:"hd_strategy_crop_triger_size"`
+	HDStrategyCropMargin        int         `json:"hd_strategy_crop_margin"`
+	HDStrategyResizeLimit       int         `json:"hd_trategy_resize_imit"`
+	Prompt                      string      `json:"prompt"`
+	NegativePrompt              string      `json:"negative_prompt"`
+	UseCroper                   bool        `json:"use_croper"`
+	CroperX                     int         `json:"croper_x"`
+	CroperY                     int         `json:"croper_y"`
+	CroperHeight                int         `json:"croper_height"`
+	CroperWidth                 int         `json:"croper_width"`
+	UseExtender                 bool        `json:"use_extender"`
+	ExtenderX                   int         `json:"extender_x"`
+	ExtenderY                   int         `json:"extender_y"`
+	ExtenderHeight              int         `json:"extender_height"`
+	ExtenderWidth               int         `json:"extender_width"`
+	SDMaskBlur                  int         `json:"sd_mask_blur"`
+	SDStrength                  float64     `json:"sd_strength"`
+	SDSteps                     int         `json:"sd_steps"`
+	SDGuidanceScale             float64     `json:"sd_guidance_scale"`
+	SDSampler                   string      `json:"sd_sampler"`
+	SDSeed                      int         `json:"sd_seed"`
+	SDMatchHistograms           bool        `json:"sd_match_histograms"`
+	SDLCMLora                   bool        `json:"sd_lcm_lora"`
+	PaintByExampleExampleImage  interface{} `json:"paint_by_example_example_image"`
+	P2PImageGuidanceScale       float64     `json:"p2p_image_guidance_scale"`
+	EnableControlnet            bool        `json:"enable_controlnet"`
+	ControlnetConditioningScale float64     `json:"controlnet_conditioning_scale"`
+	ControlnetMethod            string      `json:"controlnet_method"`
+	EnableBrushnet              bool        `json:"enable_brushnet"`
+	BrushnetMethod              string      `json:"brushnet_method"`
+	BrushnetConditioningScale   float64     `json:"brushnet_conditioning_scale"`
+	EnablePowerpaintV2          bool        `json:"enable_powerpaint_v2"`
+	PowerpaintTask              string      `json:"powerpaint_task"`
+}
+
+// iopaintFill calls the IOPaint /api/v1/inpaint endpoint and returns the full
+// result image with the masked region inpainted.
+// mask: alpha > 0 marks pixels to be filled (white in the mask sent to IOPaint).
+func (a *App) iopaintFill(src *image.NRGBA, mask *image.Alpha) (*image.NRGBA, error) {
+	// Encode source image as PNG, then base64.
+	var imgBuf bytes.Buffer
+	if err := png.Encode(&imgBuf, src); err != nil {
+		return nil, fmt.Errorf("iopaint: encode source image: %w", err)
+	}
+	imgB64 := "data:image/png;base64," + base64.StdEncoding.EncodeToString(imgBuf.Bytes())
+
+	// Build a grayscale mask PNG: white (255) where masked, black (0) elsewhere.
+	b := src.Bounds()
+	maskGray := image.NewGray(b)
+	for y := b.Min.Y; y < b.Max.Y; y++ {
+		for x := b.Min.X; x < b.Max.X; x++ {
+			if mask.AlphaAt(x, y).A > 0 {
+				maskGray.SetGray(x, y, color.Gray{Y: 255})
+			}
+		}
+	}
+	var maskBuf bytes.Buffer
+	if err := png.Encode(&maskBuf, maskGray); err != nil {
+		return nil, fmt.Errorf("iopaint: encode mask: %w", err)
+	}
+	maskB64 := "data:image/png;base64," + base64.StdEncoding.EncodeToString(maskBuf.Bytes())
+
+	reqBody := iopaintRequest{
+		Image:                       imgB64,
+		Mask:                        maskB64,
+		LDMSteps:                    30,
+		LDMSampler:                  "ddim",
+		ZITSWireframe:               true,
+		CV2Flag:                     "INPAINT_NS",
+		CV2Radius:                   5,
+		HDStrategy:                  "Crop",
+		HDStrategyCropTriggerSize:   640,
+		HDStrategyCropMargin:        128,
+		HDStrategyResizeLimit:       2048,
+		Prompt:                      "",
+		NegativePrompt:              "",
+		UseCroper:                   false,
+		CroperX:                     0,
+		CroperY:                     0,
+		CroperHeight:                512,
+		CroperWidth:                 512,
+		UseExtender:                 false,
+		ExtenderX:                   0,
+		ExtenderY:                   0,
+		ExtenderHeight:              512,
+		ExtenderWidth:               512,
+		SDMaskBlur:                  12,
+		SDStrength:                  1,
+		SDSteps:                     50,
+		SDGuidanceScale:             7.5,
+		SDSampler:                   "DPM++ 2M",
+		SDSeed:                      -1,
+		SDMatchHistograms:           false,
+		SDLCMLora:                   false,
+		PaintByExampleExampleImage:  nil,
+		P2PImageGuidanceScale:       1.5,
+		EnableControlnet:            false,
+		ControlnetConditioningScale: 0.4,
+		ControlnetMethod:            "",
+		EnableBrushnet:              false,
+		BrushnetMethod:              "random_mask",
+		BrushnetConditioningScale:   1,
+		EnablePowerpaintV2:          false,
+		PowerpaintTask:              "text-guided",
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("iopaint: marshal request: %w", err)
+	}
+
+	endpoint := strings.TrimRight(a.iopaintURL, "/") + "/api/v1/inpaint"
+	a.logf("iopaintFill: POST %s (body=%d bytes)", endpoint, len(bodyBytes))
+
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Post(endpoint, "application/json", bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("iopaint: POST %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("iopaint: server returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("iopaint: read response: %w", err)
+	}
+	a.logf("iopaintFill: response %d bytes", len(respBytes))
+
+	// Try raw image bytes first (IOPaint typically returns PNG directly).
+	out, _, decErr := image.Decode(bytes.NewReader(respBytes))
+	if decErr != nil {
+		// Fall back: try JSON {"image": "data:...;base64,..."}.
+		var jsonResp struct {
+			Image string `json:"image"`
+		}
+		if jsonErr := json.Unmarshal(respBytes, &jsonResp); jsonErr == nil && jsonResp.Image != "" {
+			imgData := jsonResp.Image
+			if idx := strings.Index(imgData, ","); idx >= 0 {
+				imgData = imgData[idx+1:]
+			}
+			if decoded, b64Err := base64.StdEncoding.DecodeString(imgData); b64Err == nil {
+				out, _, decErr = image.Decode(bytes.NewReader(decoded))
+			}
+		}
+		if decErr != nil {
+			return nil, fmt.Errorf("iopaint: decode response image: %w", decErr)
+		}
+	}
+
+	return toNRGBA(out), nil
+}

--- a/app_settings.go
+++ b/app_settings.go
@@ -1,0 +1,26 @@
+package main
+
+// TouchupSettings holds the configuration for the touch-up backend.
+type TouchupSettings struct {
+	Backend    string `json:"backend"`
+	IOPaintURL string `json:"iopaintUrl"`
+}
+
+// GetTouchupSettings returns the current touch-up backend settings.
+func (a *App) GetTouchupSettings() TouchupSettings {
+	return TouchupSettings{
+		Backend:    a.touchupBackend,
+		IOPaintURL: a.iopaintURL,
+	}
+}
+
+// SetTouchupSettings updates the touch-up backend settings.
+func (a *App) SetTouchupSettings(settings TouchupSettings) {
+	if settings.Backend == "iopaint" || settings.Backend == "patchmatch" {
+		a.touchupBackend = settings.Backend
+	}
+	if settings.IOPaintURL != "" {
+		a.iopaintURL = settings.IOPaintURL
+	}
+	a.logf("SetTouchupSettings: backend=%q url=%q", a.touchupBackend, a.iopaintURL)
+}

--- a/app_touchup.go
+++ b/app_touchup.go
@@ -3,18 +3,14 @@ package main
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"image"
 	"image/color"
 )
 
-// TouchUpFill accepts a base64-encoded PNG mask (white where the user painted)
-// and returns a non-mutating preview produced by the PatchMatch-based filler.
-func (a *App) TouchUpFill(maskB64 string, patchSize int, iterations int) (*ProcessResult, error) {
-	a.logf("TouchUpFill: patchSize=%d iterations=%d", patchSize, iterations)
-	if a.currentImage == nil {
-		return &ProcessResult{Message: "No image loaded"}, nil
-	}
-
+// buildMask decodes a base64-encoded PNG mask (white/opaque = fill region) and
+// returns an *image.Alpha sized to match the current working image.
+func (a *App) buildMask(maskB64 string) (*image.Alpha, error) {
 	data, err := base64.StdEncoding.DecodeString(maskB64)
 	if err != nil {
 		return nil, err
@@ -24,7 +20,6 @@ func (a *App) TouchUpFill(maskB64 string, patchSize int, iterations int) (*Proce
 		return nil, err
 	}
 
-	// Convert decoded image to *image.Alpha
 	b := img.Bounds()
 	mask := image.NewAlpha(b)
 	for y := b.Min.Y; y < b.Max.Y; y++ {
@@ -32,7 +27,7 @@ func (a *App) TouchUpFill(maskB64 string, patchSize int, iterations int) (*Proce
 			c := color.NRGBAModel.Convert(img.At(x, y)).(color.NRGBA)
 			aVal := c.A
 			if aVal == 0 {
-				// if no alpha channel, use luminance threshold
+				// No alpha channel: use luminance threshold.
 				lum := (299*uint32(c.R) + 587*uint32(c.G) + 114*uint32(c.B)) / 1000
 				if lum > 10 {
 					aVal = 255
@@ -42,106 +37,97 @@ func (a *App) TouchUpFill(maskB64 string, patchSize int, iterations int) (*Proce
 		}
 	}
 
-	// Resize mask to the working image size if needed
+	srcImg := a.workingImage()
+	if srcImg == nil {
+		return nil, fmt.Errorf("no image loaded")
+	}
+	tgtBounds := srcImg.Bounds()
+	if mask.Bounds().Eq(tgtBounds) {
+		return mask, nil
+	}
+
+	// Resize mask to working image dimensions.
+	gray := image.NewGray(mask.Bounds())
+	for y := mask.Bounds().Min.Y; y < mask.Bounds().Max.Y; y++ {
+		for x := mask.Bounds().Min.X; x < mask.Bounds().Max.X; x++ {
+			v := mask.Pix[(y-mask.Bounds().Min.Y)*mask.Stride+(x-mask.Bounds().Min.X)]
+			gray.Pix[(y-mask.Bounds().Min.Y)*gray.Stride+(x-mask.Bounds().Min.X)] = v
+		}
+	}
+	resized := resizeGray(gray, tgtBounds.Dx(), tgtBounds.Dy())
+	newMask := image.NewAlpha(tgtBounds)
+	for y := 0; y < tgtBounds.Dy(); y++ {
+		for x := 0; x < tgtBounds.Dx(); x++ {
+			newMask.Pix[y*newMask.Stride+x] = resized.Pix[y*resized.Stride+x]
+		}
+	}
+	return newMask, nil
+}
+
+// TouchUpFill accepts a base64-encoded PNG mask (white where the user painted)
+// and returns a non-mutating preview produced by the configured touch-up backend.
+func (a *App) TouchUpFill(maskB64 string, patchSize int, iterations int) (*ProcessResult, error) {
+	a.logf("TouchUpFill: backend=%q patchSize=%d iterations=%d", a.touchupBackend, patchSize, iterations)
+	if a.currentImage == nil {
+		return &ProcessResult{Message: "No image loaded"}, nil
+	}
+
+	mask, err := a.buildMask(maskB64)
+	if err != nil {
+		return nil, err
+	}
+
 	srcImg := a.workingImage()
 	if srcImg == nil {
 		return &ProcessResult{Message: "No image loaded"}, nil
 	}
-	tgtBounds := srcImg.Bounds()
-	if !mask.Bounds().Eq(tgtBounds) {
-		// convert Alpha -> Gray -> resizeGray -> Alpha
-		gray := image.NewGray(mask.Bounds())
-		for y := mask.Bounds().Min.Y; y < mask.Bounds().Max.Y; y++ {
-			for x := mask.Bounds().Min.X; x < mask.Bounds().Max.X; x++ {
-				v := mask.Pix[(y-mask.Bounds().Min.Y)*mask.Stride+(x-mask.Bounds().Min.X)]
-				gray.Pix[(y-mask.Bounds().Min.Y)*gray.Stride+(x-mask.Bounds().Min.X)] = v
-			}
-		}
-		resized := resizeGray(gray, tgtBounds.Dx(), tgtBounds.Dy())
-		newMask := image.NewAlpha(tgtBounds)
-		for y := 0; y < tgtBounds.Dy(); y++ {
-			for x := 0; x < tgtBounds.Dx(); x++ {
-				v := resized.Pix[y*resized.Stride+x]
-				newMask.Pix[y*newMask.Stride+x] = v
-			}
-		}
-		mask = newMask
-	}
 
-	// Run PatchMatchFill (non-destructive preview) on the working image
-	out := PatchMatchFill(srcImg, mask, patchSize, iterations)
+	var out *image.NRGBA
+	if a.touchupBackend == "iopaint" {
+		out, err = a.iopaintFill(srcImg, mask)
+		if err != nil {
+			return nil, fmt.Errorf("IOPaint fill: %w", err)
+		}
+	} else {
+		out = PatchMatchFill(srcImg, mask, patchSize, iterations)
+	}
 
 	preview, err := imageToBase64(out)
 	if err != nil {
 		return nil, err
 	}
-	b2 := out.Bounds()
-	return &ProcessResult{Preview: preview, Message: "Touch-up preview", Width: b2.Dx(), Height: b2.Dy()}, nil
+	b := out.Bounds()
+	return &ProcessResult{Preview: preview, Message: "Touch-up preview", Width: b.Dx(), Height: b.Dy()}, nil
 }
 
-// TouchUpApply applies a touch-up fill to the working image, saving an undo
-// snapshot so the change can be reverted. Returns the new preview.
+// TouchUpApply applies a touch-up fill to the working image using the configured
+// backend, saving an undo snapshot so the change can be reverted.
 func (a *App) TouchUpApply(maskB64 string, patchSize int, iterations int) (*ProcessResult, error) {
-	a.logf("TouchUpApply: patchSize=%d iterations=%d", patchSize, iterations)
+	a.logf("TouchUpApply: backend=%q patchSize=%d iterations=%d", a.touchupBackend, patchSize, iterations)
 	if a.currentImage == nil && a.warpedImage == nil {
 		return &ProcessResult{Message: "No image loaded"}, nil
 	}
 
-	data, err := base64.StdEncoding.DecodeString(maskB64)
-	if err != nil {
-		return nil, err
-	}
-	img, _, err := image.Decode(bytes.NewReader(data))
+	mask, err := a.buildMask(maskB64)
 	if err != nil {
 		return nil, err
 	}
 
-	// Convert decoded image to *image.Alpha
-	b := img.Bounds()
-	mask := image.NewAlpha(b)
-	for y := b.Min.Y; y < b.Max.Y; y++ {
-		for x := b.Min.X; x < b.Max.X; x++ {
-			c := color.NRGBAModel.Convert(img.At(x, y)).(color.NRGBA)
-			aVal := c.A
-			if aVal == 0 {
-				lum := (299*uint32(c.R) + 587*uint32(c.G) + 114*uint32(c.B)) / 1000
-				if lum > 10 {
-					aVal = 255
-				}
-			}
-			mask.Pix[(y-b.Min.Y)*mask.Stride+(x-b.Min.X)] = aVal
-		}
-	}
-
-	// Resize mask to the working image size if needed
 	srcImg := a.workingImage()
 	if srcImg == nil {
 		return &ProcessResult{Message: "No image loaded"}, nil
 	}
-	tgtBounds := srcImg.Bounds()
-	if !mask.Bounds().Eq(tgtBounds) {
-		gray := image.NewGray(mask.Bounds())
-		for y := mask.Bounds().Min.Y; y < mask.Bounds().Max.Y; y++ {
-			for x := mask.Bounds().Min.X; x < mask.Bounds().Max.X; x++ {
-				v := mask.Pix[(y-mask.Bounds().Min.Y)*mask.Stride+(x-mask.Bounds().Min.X)]
-				gray.Pix[(y-mask.Bounds().Min.Y)*gray.Stride+(x-mask.Bounds().Min.X)] = v
-			}
+
+	var out *image.NRGBA
+	if a.touchupBackend == "iopaint" {
+		out, err = a.iopaintFill(srcImg, mask)
+		if err != nil {
+			return nil, fmt.Errorf("IOPaint fill: %w", err)
 		}
-		resized := resizeGray(gray, tgtBounds.Dx(), tgtBounds.Dy())
-		newMask := image.NewAlpha(tgtBounds)
-		for y := 0; y < tgtBounds.Dy(); y++ {
-			for x := 0; x < tgtBounds.Dx(); x++ {
-				v := resized.Pix[y*resized.Stride+x]
-				newMask.Pix[y*newMask.Stride+x] = v
-			}
-		}
-		mask = newMask
+	} else {
+		out = PatchMatchFill(srcImg, mask, patchSize, iterations)
 	}
 
-	// Run PatchMatchFill and apply result
-	out := PatchMatchFill(srcImg, mask, patchSize, iterations)
-
-	// save undo snapshot and apply
 	a.saveUndo()
 	a.setWorkingImage(out)
 
@@ -149,6 +135,6 @@ func (a *App) TouchUpApply(maskB64 string, patchSize int, iterations int) (*Proc
 	if err != nil {
 		return nil, err
 	}
-	b2 := out.Bounds()
-	return &ProcessResult{Preview: preview, Message: "Touch-up applied.", Width: b2.Dx(), Height: b2.Dy()}, nil
+	b := out.Bounds()
+	return &ProcessResult{Preview: preview, Message: "Touch-up applied.", Width: b.Dx(), Height: b.Dy()}, nil
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -573,6 +573,173 @@ button:disabled {
   cursor: not-allowed;
 }
 
+/* Options button row (below save/load) */
+.options-row {
+  padding-top: 0;
+  padding-bottom: 0;
+  border-top: none;
+  border-radius: 0;
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+}
+
+button.options-btn {
+  background: #3e3e42;
+  font-size: 14px;
+  padding: 6px 12px;
+}
+
+button.options-btn:hover {
+  background: #505054;
+  color: #e0e0e0;
+}
+
+/* ── Options modal ─────────────────────────────────────────────────────────── */
+
+.options-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.options-backdrop.visible {
+  opacity: 1;
+}
+
+.options-dialog {
+  background: #2d2d30;
+  border: 1px solid #3e3e42;
+  border-radius: 8px;
+  width: 380px;
+  max-width: 92vw;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+}
+
+.options-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid #3e3e42;
+}
+
+.options-title {
+  font-weight: bold;
+  font-size: 14px;
+  color: #e0e0e0;
+}
+
+button.options-close {
+  background: none;
+  border: none;
+  color: #858585;
+  font-size: 16px;
+  padding: 0 4px;
+  width: auto;
+  cursor: pointer;
+  line-height: 1;
+}
+
+button.options-close:hover {
+  color: #e0e0e0;
+  background: none;
+}
+
+.options-body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.options-section-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  color: #858585;
+  margin-bottom: 2px;
+}
+
+.options-radio-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #e0e0e0;
+  cursor: pointer;
+}
+
+.options-radio-label input[type='radio'] {
+  accent-color: #007acc;
+  cursor: pointer;
+}
+
+.options-hint {
+  color: #858585;
+  font-size: 11px;
+}
+
+.options-iopaint-url {
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 200ms ease, opacity 180ms ease;
+}
+
+.options-iopaint-url.visible {
+  max-height: 80px;
+  opacity: 1;
+}
+
+.options-field-label {
+  display: block;
+  font-size: 11px;
+  color: #858585;
+  margin-bottom: 4px;
+}
+
+.options-text-input {
+  width: 100%;
+  background: #1e1e1e;
+  border: 1px solid #3e3e42;
+  border-radius: 4px;
+  color: #e0e0e0;
+  font-size: 13px;
+  padding: 6px 8px;
+  box-sizing: border-box;
+  font-family: monospace;
+}
+
+.options-text-input:focus {
+  outline: none;
+  border-color: #007acc;
+}
+
+.options-footer {
+  padding: 10px 16px 14px;
+  display: flex;
+  justify-content: flex-end;
+  border-top: 1px solid #3e3e42;
+}
+
+button.options-ok-btn {
+  width: auto;
+  padding: 6px 24px;
+  font-size: 13px;
+  background: #007acc;
+}
+
+button.options-ok-btn:hover {
+  background: #005a9e;
+}
+
 /* Scrollbar styling */
 .sidebar::-webkit-scrollbar {
   width: 10px;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,8 @@ import {
   GetLaunchArgs,
   GetCleanPreview,
   LogFrontend,
+  GetTouchupSettings,
+  SetTouchupSettings,
 } from '../wailsjs/go/main/App'
 
 import CornerPanel      from './components/CornerPanel'
@@ -31,6 +33,7 @@ import DiscPanel        from './components/DiscPanel'
 import LinePanel        from './components/LinePanel'
 import AdjustmentsPanel from './components/AdjustmentsPanel'
 import ShortcutsPanel   from './components/ShortcutsPanel'
+import OptionsPanel     from './components/OptionsPanel'
 
 export default function App() {
   // ── Shared state ──────────────────────────────────────────────────────────
@@ -87,6 +90,35 @@ export default function App() {
   const [useTouchupTool, setUseTouchupTool] = useState(false)
   const [touchupStrokes, setTouchupStrokes] = useState([]) // array of {x,y} in image coords
   const [brushSize, setBrushSize] = useState(40)
+
+  // ── Options state ─────────────────────────────────────────────────────────
+  const [optionsOpen, setOptionsOpen]         = useState(false)
+  const [touchupBackend, setTouchupBackendState] = useState(() =>
+    localStorage.getItem('touchupBackend') || 'patchmatch'
+  )
+  const [iopaintURL, setIopaintURLState] = useState(() =>
+    localStorage.getItem('iopaintURL') || 'http://127.0.0.1:8086/'
+  )
+
+  // Persist and push to backend whenever either setting changes.
+  const setTouchupBackend = (v) => {
+    setTouchupBackendState(v)
+    localStorage.setItem('touchupBackend', v)
+    SetTouchupSettings({ backend: v, iopaintUrl: iopaintURL }).catch(() => {})
+  }
+  const setIopaintURL = (v) => {
+    setIopaintURLState(v)
+    localStorage.setItem('iopaintURL', v)
+    SetTouchupSettings({ backend: touchupBackend, iopaintUrl: v }).catch(() => {})
+  }
+
+  // Push persisted settings to backend on startup.
+  useEffect(() => {
+    SetTouchupSettings({
+      backend: localStorage.getItem('touchupBackend') || 'patchmatch',
+      iopaintUrl: localStorage.getItem('iopaintURL') || 'http://127.0.0.1:8086/',
+    }).catch(() => {})
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const clearTouchup = () => setTouchupStrokes([])
 
@@ -933,9 +965,21 @@ export default function App() {
             <button onClick={handleSaveImage} className="save-btn" disabled={loading}>
               Save image
             </button>
+            <button className="options-btn" onClick={() => setOptionsOpen(true)}>
+              Options
+            </button>
           </div>
         </div>
       </aside>
+
+      <OptionsPanel
+        open={optionsOpen}
+        onClose={() => setOptionsOpen(false)}
+        touchupBackend={touchupBackend}
+        setTouchupBackend={setTouchupBackend}
+        iopaintURL={iopaintURL}
+        setIopaintURL={setIopaintURL}
+      />
 
       <main className="main-content">
         <header className="toolbar">

--- a/frontend/src/components/DelayedHint.jsx
+++ b/frontend/src/components/DelayedHint.jsx
@@ -3,21 +3,24 @@ import ReactDOM from 'react-dom'
 
 // DelayedHint: shows a tooltip after hovering for a delay (default 1s),
 // rendered in a portal to avoid clipping by overflow:hidden parents.
-export default function DelayedHint({ children, hint, delay = 1000, offset = 10 }) {
+export default function DelayedHint({ children, hint, delay = 1000, offset = 12 }) {
   const [showHint, setShowHint] = React.useState(false)
   const [hintPos, setHintPos] = React.useState({ top: 0, left: 0 })
   const hintTimeout = React.useRef()
   const childRef = React.useRef()
+  const cursorPos = React.useRef({ x: 0, y: 0 })
 
-  const handleShow = () => {
+  const handleMove = (e) => {
+    cursorPos.current = { x: e.clientX, y: e.clientY }
+  }
+
+  const handleShow = (e) => {
+    cursorPos.current = { x: e.clientX, y: e.clientY }
     hintTimeout.current = setTimeout(() => {
-      if (childRef.current) {
-        const rect = childRef.current.getBoundingClientRect()
-        setHintPos({
-          top: rect.top + rect.height / 2,
-          left: rect.right + offset,
-        })
-      }
+      setHintPos({
+        top: cursorPos.current.y,
+        left: cursorPos.current.x + offset,
+      })
       setShowHint(true)
     }, delay)
   }
@@ -40,9 +43,12 @@ export default function DelayedHint({ children, hint, delay = 1000, offset = 10 
             fontSize: 13,
             borderRadius: 4,
             padding: '4px 10px',
-            whiteSpace: 'nowrap',
+            maxWidth: 280,
+            whiteSpace: 'normal',
+            wordBreak: 'break-word',
             zIndex: 9999,
             boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+            lineHeight: 1.4,
           }}
         >
           {hint}
@@ -56,6 +62,7 @@ export default function DelayedHint({ children, hint, delay = 1000, offset = 10 
     ref: childRef,
     onMouseEnter: handleShow,
     onMouseLeave: handleHide,
+    onMouseMove: handleMove,
     onBlur: handleHide,
     tabIndex: child.props.tabIndex || 0,
   })

--- a/frontend/src/components/OptionsPanel.jsx
+++ b/frontend/src/components/OptionsPanel.jsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useState } from 'react'
+import DelayedHint from './DelayedHint'
+
+const FADE_MS = 150
+
+// OptionsPanel renders a modal dialog for configuring application options.
+// Currently exposes touch-up backend selection (PatchMatch vs IOPaint).
+// Props:
+//   open / onClose
+//   touchupBackend / setTouchupBackend  ('patchmatch' | 'iopaint')
+//   iopaintURL / setIopaintURL
+export default function OptionsPanel({
+  open,
+  onClose,
+  touchupBackend,
+  setTouchupBackend,
+  iopaintURL,
+  setIopaintURL,
+}) {
+  const dialogRef = useRef(null)
+  const [mounted, setMounted] = useState(false)
+  const [shown, setShown]     = useState(false)
+  const fadeOutTimer = useRef(null)
+
+  useEffect(() => {
+    if (open) {
+      clearTimeout(fadeOutTimer.current)
+      setMounted(true)
+      // one frame delay so the browser registers the initial opacity:0 before transitioning
+      requestAnimationFrame(() => requestAnimationFrame(() => setShown(true)))
+    } else {
+      setShown(false)
+      fadeOutTimer.current = setTimeout(() => setMounted(false), FADE_MS)
+    }
+    return () => clearTimeout(fadeOutTimer.current)
+  }, [open])
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!open) return
+    const handler = (e) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [open, onClose])
+
+  if (!mounted) return null
+
+  return (
+    <div className={`options-backdrop ${shown ? 'visible' : ''}`} onClick={onClose}>
+      <div
+        ref={dialogRef}
+        className="options-dialog"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Options"
+      >
+        <div className="options-header">
+          <span className="options-title">Options</span>
+          <button className="options-close" onClick={onClose} aria-label="Close">✕</button>
+        </div>
+
+        <div className="options-body">
+          <DelayedHint hint="The touch-up brush lets you paint over blemishes or unwanted areas. The backend controls how the masked region is filled in.">
+            <div className="options-section-title" tabIndex={0}>Touch-up backend</div>
+          </DelayedHint>
+
+          <DelayedHint hint="PatchMatch is a built-in content-aware fill. It samples nearby patches to reconstruct the masked area entirely on your CPU, no server required.">
+            <label className="options-radio-label">
+              <input
+                type="radio"
+                name="touchup-backend"
+                value="patchmatch"
+                checked={touchupBackend === 'patchmatch'}
+                onChange={() => setTouchupBackend('patchmatch')}
+              />
+              PatchMatch <span className="options-hint">(built-in, works offline)</span>
+            </label>
+          </DelayedHint>
+
+          <DelayedHint hint="IOPaint (formerly lama-cleaner) is an AI inpainting server you run locally. It can produce much higher quality touch-ups than conventional algorithms by leveraging deep-learning models.">
+            <label className="options-radio-label">
+              <input
+                type="radio"
+                name="touchup-backend"
+                value="iopaint"
+                checked={touchupBackend === 'iopaint'}
+                onChange={() => setTouchupBackend('iopaint')}
+              />
+              IOPaint <span className="options-hint">(AI inpainting via local server)</span>
+            </label>
+          </DelayedHint>
+
+          <div className={`options-iopaint-url ${touchupBackend === 'iopaint' ? 'visible' : ''}`}>
+            <label className="options-field-label" htmlFor="iopaint-url">IOPaint endpoint URL</label>
+            <DelayedHint hint="Base URL of your running IOPaint server, e.g. by default, the app will make requests to /api/v1/inpaint at http://127.0.0.1:8086/.">
+              <input
+                id="iopaint-url"
+                className="options-text-input"
+                type="text"
+                value={iopaintURL}
+                onChange={(e) => setIopaintURL(e.target.value)}
+                placeholder="http://127.0.0.1:8086/"
+                spellCheck={false}
+              />
+            </DelayedHint>
+          </div>
+        </div>
+
+        <div className="options-footer">
+          <button className="options-ok-btn" onClick={onClose}>OK</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -22,6 +22,8 @@ export function GetLaunchArgs():Promise<main.LaunchArgs>;
 
 export function GetPixelColor(arg1:main.PixelColorRequest):Promise<main.ProcessResult>;
 
+export function GetTouchupSettings():Promise<main.TouchupSettings>;
+
 export function LoadImage(arg1:main.LoadImageRequest):Promise<main.ImageInfo>;
 
 export function LogFrontend(arg1:string):Promise<void>;
@@ -49,6 +51,8 @@ export function SetCornerDotRadius(arg1:any):Promise<main.ProcessResult>;
 export function SetFeatherSize(arg1:main.FeatherSizeRequest):Promise<main.ProcessResult>;
 
 export function SetLevels(arg1:main.SetLevelsRequest):Promise<main.ProcessResult>;
+
+export function SetTouchupSettings(arg1:main.TouchupSettings):Promise<void>;
 
 export function ShiftDisc(arg1:main.ShiftDiscRequest):Promise<main.ProcessResult>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -42,6 +42,10 @@ export function GetPixelColor(arg1) {
   return window['go']['main']['App']['GetPixelColor'](arg1);
 }
 
+export function GetTouchupSettings() {
+  return window['go']['main']['App']['GetTouchupSettings']();
+}
+
 export function LoadImage(arg1) {
   return window['go']['main']['App']['LoadImage'](arg1);
 }
@@ -96,6 +100,10 @@ export function SetFeatherSize(arg1) {
 
 export function SetLevels(arg1) {
   return window['go']['main']['App']['SetLevels'](arg1);
+}
+
+export function SetTouchupSettings(arg1) {
+  return window['go']['main']['App']['SetTouchupSettings'](arg1);
 }
 
 export function ShiftDisc(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -262,6 +262,20 @@ export namespace main {
 	        this.dy = source["dy"];
 	    }
 	}
+	export class TouchupSettings {
+	    backend: string;
+	    iopaintUrl: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new TouchupSettings(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.backend = source["backend"];
+	        this.iopaintUrl = source["iopaintUrl"];
+	    }
+	}
 
 }
 


### PR DESCRIPTION
Just as the title says, this makes IOPaint available as a touch-up backend. Naturally, this PR also introduces some initial scaffolding for future backend implementations. It is disabled by default but can be configured in a new options modal also made available in this PR.

Merging this PR will resolve #3.