### PR TITLE
Add out-of-bounds fill settings and functionality for perspective warping

### DIFF
--- a/app.go
+++ b/app.go
@@ -63,6 +63,10 @@ type App struct {
 	// Touch-up backend settings
 	touchupBackend string // "patchmatch" or "iopaint"
 	iopaintURL     string
+
+	// Warp out-of-bounds fill settings
+	warpFillMode  string      // "clamp", "fill", or "outpaint"
+	warpFillColor color.NRGBA // used when warpFillMode == "fill"
 }
 
 // NewApp creates a new App application struct.
@@ -76,6 +80,8 @@ func NewApp() *App {
 		postDiscWhite:  255,
 		touchupBackend: "patchmatch",
 		iopaintURL:     "http://127.0.0.1:8086/",
+		warpFillMode:   "clamp",
+		warpFillColor:  color.NRGBA{R: 255, G: 255, B: 255, A: 255},
 	}
 }
 

--- a/app_corner.go
+++ b/app_corner.go
@@ -84,13 +84,54 @@ func (a *App) warpFromCorners(corners []image.Point) (*image.NRGBA, int, int, er
 	dst := [4]image.Point{
 		{0, 0}, {width, 0}, {0, height}, {width, height},
 	}
-	warped := perspectiveTransform(a.currentImage,
-		[4]image.Point{sorted[0], sorted[1], sorted[2], sorted[3]},
-		dst, width, height)
+	srcPts := [4]image.Point{sorted[0], sorted[1], sorted[2], sorted[3]}
+
+	var warped *image.NRGBA
+	if a.warpFillMode == "clamp" {
+		warped = perspectiveTransform(a.currentImage, srcPts, dst, width, height)
+	} else {
+		var oobMask *image.Alpha
+		warped, oobMask = perspectiveTransformWithMask(a.currentImage, srcPts, dst, width, height)
+		warped = a.applyWarpFill(warped, oobMask)
+	}
 
 	a.warpedImage = warped
 	a.cropTop, a.cropBottom, a.cropLeft, a.cropRight = 0, 0, 0, 0
 	return warped, width, height, nil
+}
+
+// applyWarpFill fills out-of-bounds pixels (marked in oobMask) according to
+// the configured warpFillMode.
+func (a *App) applyWarpFill(img *image.NRGBA, oobMask *image.Alpha) *image.NRGBA {
+	// Fast path: nothing is OOB.
+	hasOOB := false
+	for _, v := range oobMask.Pix {
+		if v > 0 {
+			hasOOB = true
+			break
+		}
+	}
+	if !hasOOB {
+		return img
+	}
+
+	if a.warpFillMode == "outpaint" {
+		out := PatchMatchFill(img, oobMask, 9, 5)
+		a.logf("applyWarpFill: outpaint OK")
+		return out
+	}
+
+	// Solid fill: paint OOB pixels with warpFillColor.
+	b := img.Bounds()
+	fc := a.warpFillColor
+	for y := b.Min.Y; y < b.Max.Y; y++ {
+		for x := b.Min.X; x < b.Max.X; x++ {
+			if oobMask.AlphaAt(x, y).A > 0 {
+				img.SetNRGBA(x, y, fc)
+			}
+		}
+	}
+	return img
 }
 
 // DetectCorners detects corners in the current image using Shi-Tomasi algorithm.

--- a/app_line.go
+++ b/app_line.go
@@ -118,7 +118,14 @@ func (a *App) ProcessLines() (*ProcessResult, error) {
 	}
 	src := [4]image.Point{tl, tr, br, bl}
 
-	warped := perspectiveTransform(a.originalImage, src, dst, outW, outH)
+	var warped *image.NRGBA
+	if a.warpFillMode == "clamp" {
+		warped = perspectiveTransform(a.originalImage, src, dst, outW, outH)
+	} else {
+		var oobMask *image.Alpha
+		warped, oobMask = perspectiveTransformWithMask(a.originalImage, src, dst, outW, outH)
+		warped = a.applyWarpFill(warped, oobMask)
+	}
 	a.warpedImage = warped
 	a.lines = nil
 

--- a/app_settings.go
+++ b/app_settings.go
@@ -1,5 +1,11 @@
 package main
 
+import (
+	"fmt"
+	"image/color"
+	"strings"
+)
+
 // TouchupSettings holds the configuration for the touch-up backend.
 type TouchupSettings struct {
 	Backend    string `json:"backend"`
@@ -23,4 +29,52 @@ func (a *App) SetTouchupSettings(settings TouchupSettings) {
 		a.iopaintURL = settings.IOPaintURL
 	}
 	a.logf("SetTouchupSettings: backend=%q url=%q", a.touchupBackend, a.iopaintURL)
+}
+
+// WarpSettings holds configuration for how out-of-bounds regions produced by
+// perspective warping are handled.
+type WarpSettings struct {
+	// FillMode is "clamp", "fill" (solid colour), or "outpaint" (PatchMatch).
+	FillMode string `json:"fillMode"`
+	// FillColor is a CSS hex colour string (e.g. "#ffffff") used when FillMode=="fill".
+	FillColor string `json:"fillColor"`
+}
+
+// GetWarpSettings returns the current warp out-of-bounds fill settings.
+func (a *App) GetWarpSettings() WarpSettings {
+	c := a.warpFillColor
+	return WarpSettings{
+		FillMode:  a.warpFillMode,
+		FillColor: fmt.Sprintf("#%02x%02x%02x", c.R, c.G, c.B),
+	}
+}
+
+// SetWarpSettings updates the warp out-of-bounds fill settings.
+func (a *App) SetWarpSettings(settings WarpSettings) {
+	if settings.FillMode == "clamp" || settings.FillMode == "fill" || settings.FillMode == "outpaint" {
+		a.warpFillMode = settings.FillMode
+	}
+	if settings.FillColor != "" {
+		if c, err := parseHexColor(settings.FillColor); err == nil {
+			a.warpFillColor = c
+		}
+	}
+	a.logf("SetWarpSettings: fillMode=%q fillColor=%q", a.warpFillMode, settings.FillColor)
+}
+
+// parseHexColor parses a CSS hex colour string ("#rrggbb" or "#rgb") into color.NRGBA.
+func parseHexColor(s string) (color.NRGBA, error) {
+	s = strings.TrimPrefix(s, "#")
+	if len(s) == 3 {
+		s = string([]byte{s[0], s[0], s[1], s[1], s[2], s[2]})
+	}
+	if len(s) != 6 {
+		return color.NRGBA{}, fmt.Errorf("invalid hex color %q", s)
+	}
+	var r, g, b uint8
+	_, err := fmt.Sscanf(s, "%02x%02x%02x", &r, &g, &b)
+	if err != nil {
+		return color.NRGBA{}, err
+	}
+	return color.NRGBA{R: r, G: g, B: b, A: 255}, nil
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -690,12 +690,14 @@ button.options-close:hover {
   max-height: 0;
   overflow: hidden;
   opacity: 0;
-  transition: max-height 200ms ease, opacity 180ms ease;
+  margin-top: -10px;
+  transition: max-height 200ms ease, opacity 180ms ease, margin-top 200ms ease;
 }
 
 .options-iopaint-url.visible {
   max-height: 80px;
   opacity: 1;
+  margin-top: 0;
 }
 
 .options-field-label {
@@ -720,6 +722,21 @@ button.options-close:hover {
 .options-text-input:focus {
   outline: none;
   border-color: #007acc;
+}
+
+.options-divider {
+  border-top: 1px solid #3e3e42;
+  margin: 4px 0;
+}
+
+.options-color-input {
+  width: 48px;
+  height: 28px;
+  padding: 2px;
+  border: 1px solid #3e3e42;
+  border-radius: 4px;
+  background: #1e1e1e;
+  cursor: pointer;
 }
 
 .options-footer {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,8 @@ import {
   LogFrontend,
   GetTouchupSettings,
   SetTouchupSettings,
+  GetWarpSettings,
+  SetWarpSettings,
 } from '../wailsjs/go/main/App'
 
 import CornerPanel      from './components/CornerPanel'
@@ -112,11 +114,33 @@ export default function App() {
     SetTouchupSettings({ backend: touchupBackend, iopaintUrl: v }).catch(() => {})
   }
 
-  // Push persisted settings to backend on startup.
+  const [warpFillMode, setWarpFillModeState] = useState(() =>
+    localStorage.getItem('warpFillMode') || 'clamp'
+  )
+  const [warpFillColor, setWarpFillColorState] = useState(() =>
+    localStorage.getItem('warpFillColor') || '#ffffff'
+  )
+
+  const setWarpFillMode = (v) => {
+    setWarpFillModeState(v)
+    localStorage.setItem('warpFillMode', v)
+    SetWarpSettings({ fillMode: v, fillColor: warpFillColor }).catch(() => {})
+  }
+  const setWarpFillColor = (v) => {
+    setWarpFillColorState(v)
+    localStorage.setItem('warpFillColor', v)
+    SetWarpSettings({ fillMode: warpFillMode, fillColor: v }).catch(() => {})
+  }
+
+  // Push all persisted settings to backend on startup.
   useEffect(() => {
     SetTouchupSettings({
       backend: localStorage.getItem('touchupBackend') || 'patchmatch',
       iopaintUrl: localStorage.getItem('iopaintURL') || 'http://127.0.0.1:8086/',
+    }).catch(() => {})
+    SetWarpSettings({
+      fillMode:  localStorage.getItem('warpFillMode')  || 'clamp',
+      fillColor: localStorage.getItem('warpFillColor') || '#ffffff',
     }).catch(() => {})
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -979,6 +1003,10 @@ export default function App() {
         setTouchupBackend={setTouchupBackend}
         iopaintURL={iopaintURL}
         setIopaintURL={setIopaintURL}
+        warpFillMode={warpFillMode}
+        setWarpFillMode={setWarpFillMode}
+        warpFillColor={warpFillColor}
+        setWarpFillColor={setWarpFillColor}
       />
 
       <main className="main-content">

--- a/frontend/src/components/OptionsPanel.jsx
+++ b/frontend/src/components/OptionsPanel.jsx
@@ -4,11 +4,12 @@ import DelayedHint from './DelayedHint'
 const FADE_MS = 150
 
 // OptionsPanel renders a modal dialog for configuring application options.
-// Currently exposes touch-up backend selection (PatchMatch vs IOPaint).
 // Props:
 //   open / onClose
 //   touchupBackend / setTouchupBackend  ('patchmatch' | 'iopaint')
 //   iopaintURL / setIopaintURL
+//   warpFillMode / setWarpFillMode  ('clamp' | 'fill' | 'outpaint')
+//   warpFillColor / setWarpFillColor  (CSS hex string)
 export default function OptionsPanel({
   open,
   onClose,
@@ -16,6 +17,10 @@ export default function OptionsPanel({
   setTouchupBackend,
   iopaintURL,
   setIopaintURL,
+  warpFillMode,
+  setWarpFillMode,
+  warpFillColor,
+  setWarpFillColor,
 }) {
   const dialogRef = useRef(null)
   const [mounted, setMounted] = useState(false)
@@ -65,7 +70,7 @@ export default function OptionsPanel({
             <div className="options-section-title" tabIndex={0}>Touch-up backend</div>
           </DelayedHint>
 
-          <DelayedHint hint="PatchMatch is a built-in content-aware fill. It samples nearby patches to reconstruct the masked area entirely on your CPU, no server required.">
+          <DelayedHint hint="PatchMatch is a built-in content-aware fill. It samples nearby patches to reconstruct the masked area entirely on your CPU, no server or internet connection required.">
             <label className="options-radio-label">
               <input
                 type="radio"
@@ -74,7 +79,7 @@ export default function OptionsPanel({
                 checked={touchupBackend === 'patchmatch'}
                 onChange={() => setTouchupBackend('patchmatch')}
               />
-              PatchMatch <span className="options-hint">(built-in, works offline)</span>
+              PatchMatch <span className="options-hint">(default)</span>
             </label>
           </DelayedHint>
 
@@ -105,6 +110,64 @@ export default function OptionsPanel({
               />
             </DelayedHint>
           </div>
+
+          <div className="options-divider" />
+
+          <DelayedHint hint="When the perspective crop extends beyond the scan boundary, this setting controls how those regions are handled.">
+            <div className="options-section-title" tabIndex={0}>Out-of-bounds fill</div>
+          </DelayedHint>
+
+          <DelayedHint hint="Clamps source coordinates to the image boundary, repeating edge pixels into any out-of-bounds region. No region is ever left blank or transparent.">
+            <label className="options-radio-label">
+              <input
+                type="radio"
+                name="warp-fill-mode"
+                value="clamp"
+                checked={warpFillMode === 'clamp'}
+                onChange={() => setWarpFillMode('clamp')}
+              />
+              Clamp to boundary <span className="options-hint">(default)</span>
+            </label>
+          </DelayedHint>
+
+          <DelayedHint hint="Fills the out-of-bounds region with a solid colour. Use the colour picker to choose the fill colour (default: white).">
+            <label className="options-radio-label">
+              <input
+                type="radio"
+                name="warp-fill-mode"
+                value="fill"
+                checked={warpFillMode === 'fill'}
+                onChange={() => setWarpFillMode('fill')}
+              />
+              Solid fill
+            </label>
+          </DelayedHint>
+
+          <div className={`options-iopaint-url ${warpFillMode === 'fill' ? 'visible' : ''}`}>
+            <label className="options-field-label" htmlFor="warp-fill-color">Fill colour</label>
+            <DelayedHint hint="The colour used to fill regions outside the scan. White works well for most scanned documents.">
+              <input
+                id="warp-fill-color"
+                className="options-color-input"
+                type="color"
+                value={warpFillColor}
+                onChange={(e) => setWarpFillColor(e.target.value)}
+              />
+            </DelayedHint>
+          </div>
+
+          <DelayedHint hint="Outpaints using PatchMatch, synthesising plausible content from the surrounding scan rather than leaving a flat colour.">
+            <label className="options-radio-label">
+              <input
+                type="radio"
+                name="warp-fill-mode"
+                value="outpaint"
+                checked={warpFillMode === 'outpaint'}
+                onChange={() => setWarpFillMode('outpaint')}
+              />
+              Outpaint <span className="options-hint">(built-in PatchMatch)</span>
+            </label>
+          </DelayedHint>
         </div>
 
         <div className="options-footer">

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -24,6 +24,8 @@ export function GetPixelColor(arg1:main.PixelColorRequest):Promise<main.ProcessR
 
 export function GetTouchupSettings():Promise<main.TouchupSettings>;
 
+export function GetWarpSettings():Promise<main.WarpSettings>;
+
 export function LoadImage(arg1:main.LoadImageRequest):Promise<main.ImageInfo>;
 
 export function LogFrontend(arg1:string):Promise<void>;
@@ -53,6 +55,8 @@ export function SetFeatherSize(arg1:main.FeatherSizeRequest):Promise<main.Proces
 export function SetLevels(arg1:main.SetLevelsRequest):Promise<main.ProcessResult>;
 
 export function SetTouchupSettings(arg1:main.TouchupSettings):Promise<void>;
+
+export function SetWarpSettings(arg1:main.WarpSettings):Promise<void>;
 
 export function ShiftDisc(arg1:main.ShiftDiscRequest):Promise<main.ProcessResult>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -46,6 +46,10 @@ export function GetTouchupSettings() {
   return window['go']['main']['App']['GetTouchupSettings']();
 }
 
+export function GetWarpSettings() {
+  return window['go']['main']['App']['GetWarpSettings']();
+}
+
 export function LoadImage(arg1) {
   return window['go']['main']['App']['LoadImage'](arg1);
 }
@@ -104,6 +108,10 @@ export function SetLevels(arg1) {
 
 export function SetTouchupSettings(arg1) {
   return window['go']['main']['App']['SetTouchupSettings'](arg1);
+}
+
+export function SetWarpSettings(arg1) {
+  return window['go']['main']['App']['SetWarpSettings'](arg1);
 }
 
 export function ShiftDisc(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -276,6 +276,20 @@ export namespace main {
 	        this.iopaintUrl = source["iopaintUrl"];
 	    }
 	}
+	export class WarpSettings {
+	    fillMode: string;
+	    fillColor: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new WarpSettings(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.fillMode = source["fillMode"];
+	        this.fillColor = source["fillColor"];
+	    }
+	}
 
 }
 

--- a/imgproc.go
+++ b/imgproc.go
@@ -621,6 +621,77 @@ func perspectiveTransform(src *image.NRGBA, srcPts, dstPts [4]image.Point, outW,
 	return dst
 }
 
+// perspectiveTransformWithMask is like perspectiveTransform but instead of
+// clamping out-of-bounds source coordinates it leaves those destination pixels
+// transparent and records them in the returned alpha mask (255 = OOB).
+// Callers can then decide how to fill the masked region.
+func perspectiveTransformWithMask(src *image.NRGBA, srcPts, dstPts [4]image.Point, outW, outH int) (*image.NRGBA, *image.Alpha) {
+	H := computeHomography(
+		[4][2]float64{
+			{float64(srcPts[0].X), float64(srcPts[0].Y)},
+			{float64(srcPts[1].X), float64(srcPts[1].Y)},
+			{float64(srcPts[2].X), float64(srcPts[2].Y)},
+			{float64(srcPts[3].X), float64(srcPts[3].Y)},
+		},
+		[4][2]float64{
+			{float64(dstPts[0].X), float64(dstPts[0].Y)},
+			{float64(dstPts[1].X), float64(dstPts[1].Y)},
+			{float64(dstPts[2].X), float64(dstPts[2].Y)},
+			{float64(dstPts[3].X), float64(dstPts[3].Y)},
+		},
+	)
+
+	Hinv := invert3x3(H)
+
+	dst := image.NewNRGBA(image.Rect(0, 0, outW, outH))
+	oob := image.NewAlpha(image.Rect(0, 0, outW, outH))
+	sb := src.Bounds()
+
+	for y := 0; y < outH; y++ {
+		for x := 0; x < outW; x++ {
+			dx, dy := float64(x)+0.5, float64(y)+0.5
+			w := Hinv[6]*dx + Hinv[7]*dy + Hinv[8]
+			if math.Abs(w) < 1e-12 {
+				oob.Pix[y*oob.Stride+x] = 255
+				continue
+			}
+			sx := (Hinv[0]*dx + Hinv[1]*dy + Hinv[2]) / w
+			sy := (Hinv[3]*dx + Hinv[4]*dy + Hinv[5]) / w
+
+			ix0 := int(math.Floor(sx))
+			iy0 := int(math.Floor(sy))
+
+			// Mark pixel as out-of-bounds if bilinear neighbourhood is outside src.
+			if ix0 < sb.Min.X || ix0 > sb.Max.X-2 || iy0 < sb.Min.Y || iy0 > sb.Max.Y-2 {
+				oob.Pix[y*oob.Stride+x] = 255
+				continue
+			}
+
+			ffx := sx - float64(ix0)
+			ffy := sy - float64(iy0)
+
+			c00 := src.NRGBAAt(ix0, iy0)
+			c10 := src.NRGBAAt(ix0+1, iy0)
+			c01 := src.NRGBAAt(ix0, iy0+1)
+			c11 := src.NRGBAAt(ix0+1, iy0+1)
+
+			r := bilinear(float64(c00.R), float64(c10.R), float64(c01.R), float64(c11.R), ffx, ffy)
+			g := bilinear(float64(c00.G), float64(c10.G), float64(c01.G), float64(c11.G), ffx, ffy)
+			bl := bilinear(float64(c00.B), float64(c10.B), float64(c01.B), float64(c11.B), ffx, ffy)
+			al := bilinear(float64(c00.A), float64(c10.A), float64(c01.A), float64(c11.A), ffx, ffy)
+
+			dst.SetNRGBA(x, y, color.NRGBA{
+				R: clampByte(int(r)),
+				G: clampByte(int(g)),
+				B: clampByte(int(bl)),
+				A: clampByte(int(al)),
+			})
+		}
+	}
+
+	return dst, oob
+}
+
 // ---- Rotation ----
 
 // rotate90 rotates an image 90 degrees. flipCode 0 = CCW, 1 = CW.


### PR DESCRIPTION
- Introduced warpFillMode and warpFillColor in App struct for configuring out-of-bounds pixel handling.
- Implemented applyWarpFill method to fill out-of-bounds regions based on the selected mode (clamp, fill, inpaint).
- Updated perspectiveTransformWithMask to return an alpha mask for out-of-bounds pixels.
- Enhanced UI components to allow user configuration of warp fill settings.
- Added corresponding methods in the backend for managing warp settings.

Merging this PR will resolve #5.